### PR TITLE
Few small changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,31 +1,14 @@
-# LabFlow
+# Flow
 
-An open-source configurable LIMS for biotech labs.
+Flow by LabGrid is an open-source configurable workflow manager with a React/Typescript frontend, Python Flask backend, and Postgres database.  
 
-## Development
+This project is currently under active development. See the getting started documentation to run the app using Docker and Auth0 for user auth. Hosted version coming soon.
 
-Development docker containers that support hot code reloading on edit are provided.
+## Philosophy
 
-To run labflow in development mode:
+We want to make a self-hosted workflow manager for companies and biotech labs that have privacy and security concerns about their data going to third party services. We are striving for an easy-to-deploy solution that can be used in regulated lab environments. Flow by LabGrid gives you full control over your lab's workflows and data. 
 
-```
-# First, setup your environment.
-cp example.env .env
+## Documentation
 
-# Edit the .env file to contain secrets appropriate for your environment.
+[Getting started with development](https://github.com/lab-grid/flow/wiki/Getting-Started)
 
-docker-compose build
-docker-compose up
-```
-
-Once the database, server, and webapp are running, the database itself needs to have its schema setup/updated.
-
-### Updating your database
-
-Whenever changes to the database schema for labflow are made, new migration(s) get created in the
-`server/migrations/versions/` directory. To update your database to the latest version, first start
-the database and server containers, then run:
-
-```
-./server.sh db upgrade
-```

--- a/README.md
+++ b/README.md
@@ -16,7 +16,33 @@ We want to make a self-hosted workflow manager for companies and biotech labs th
 - **For your whole team** - share protocols with teammates, view runs across the team
 - **Built with Postgres, React, Flask** - optimized for responsiveness, fault-tolerance, and support for regulated environments. Backend based on Python means easy integration of scientific libraries.
 
-## Documentation
+# Getting Started
 
-[Getting started with development](https://github.com/lab-grid/flow/wiki/Getting-Started)
+Flow by LabGrid is currently under active development. Development docker containers that support hot code reloading on edit are provided.
+
+## First, setup your environment.
+```
+cp example.env .env
+```
+
+Edit the .env file to contain secrets appropriate for your environment.
+
+## Launch database, server, and webapp.
+
+```
+docker-compose build
+docker-compose up
+```
+
+Once the database, server, and webapp are running, the database itself needs to have its schema setup/updated.
+
+## Updating your database
+
+Whenever changes to the database schema for Flow are made, new migration(s) get created in the server/migrations/versions/ directory. To update your database to the latest version, first start the database and server containers, then run:
+
+```
+./server.sh db upgrade
+```
+
+[Additional documentation](https://github.com/lab-grid/flow/wiki/Getting-Started)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Flow
+# Flow by LabGrid
 
 Flow by LabGrid is an open-source configurable workflow manager with a React/Typescript frontend, Python Flask backend, and Postgres database.  
 
@@ -7,6 +7,14 @@ This project is currently under active development. See the getting started docu
 ## Philosophy
 
 We want to make a self-hosted workflow manager for companies and biotech labs that have privacy and security concerns about their data going to third party services. We are striving for an easy-to-deploy solution that can be used in regulated lab environments. Flow by LabGrid gives you full control over your lab's workflows and data. 
+
+## Features
+- **Custom workflow manager** - a customizable workflow manager you can deploy in your own environment 
+- **Drag and drop protocol widgets** - easy to make new workflow widgets
+- **Audit trails and reporting** - reports available for all events
+- **React Native support** - (work in progress)
+- **For your whole team** - share protocols with teammates, view runs across the team
+- **Built with Postgres, React, Flask** - optimized for responsiveness, fault-tolerance, and support for regulated environments. Backend based on Python means easy integration of scientific libraries.
 
 ## Documentation
 

--- a/example.env
+++ b/example.env
@@ -1,5 +1,6 @@
 POSTGRES_PASSWORD=some-postgres-password
 API_URL=http://localhost:5000
+SERVER_NAME=localhost:5000
 
 AUTH_PROVIDER=auth0
 AUTH0_DOMAIN=a-domain.us.auth0.com

--- a/server/server.py
+++ b/server/server.py
@@ -48,7 +48,7 @@ authorizations = {
 }
 api = Api(
     app,
-    title='LabFlow API',
+    title='Flow by LabGrid API',
     version='0.1.0',
     authorizations=authorizations,
 )

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -4,6 +4,6 @@ import App from './App';
 
 test('renders learn react link', () => {
   const { getByText } = render(<App />);
-  const linkElement = getByText(/LabFlow/i);
+  const linkElement = getByText(/Flow by LabGrid/i);
   expect(linkElement).toBeInTheDocument();
 });

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -33,7 +33,7 @@ export default function App() {
       <Navbar bg="dark" variant="dark">
         <Navbar.Brand>
           <Link to="/">
-            LabFlow
+            Flow by LabGrid
             </Link>
         </Navbar.Brand>
         <Nav className="mr-auto"></Nav>

--- a/web/src/components/ProtocolBlockEditor.tsx
+++ b/web/src/components/ProtocolBlockEditor.tsx
@@ -149,7 +149,7 @@ function ProtocolBlockPlateCountEditor({ plateCount, setPlateCount }: {
         <Form.Label>Number of plates</Form.Label>
         <Form.Control
             type="number"
-            placeholder="Enter a name"
+            placeholder="Enter a number"
             value={plateCount}
             onChange={(e: React.ChangeEvent<HTMLInputElement>) => setPlateCount(parseInt((e.target as HTMLInputElement).value))}
         />

--- a/web/src/components/RunBlockEditor.tsx
+++ b/web/src/components/RunBlockEditor.tsx
@@ -124,7 +124,7 @@ function RunBlockPlateSamplerEditor({definition, outputPlateLabel, setOutputPlat
             <th>Output Plate</th>
             <td>
                 <RunBlockPlateLabelEditor
-                    wells={398}
+                    wells={384}
                     label={outputPlateLabel}
                     setLabel={setOutputPlateLabel}
                 />


### PR DESCRIPTION
Changed name from LabFlow to Flow by Labgrid. 
Moved documentation to the Wiki tab instead of the README because this seems to be a common pattern (to keep the README from getting too verbose).
Also fixed a few small typos.