### PR TITLE
 #9. Fixes run loading.

### DIFF
--- a/server/api/protocol.py
+++ b/server/api/protocol.py
@@ -63,6 +63,7 @@ class ProtocolResource(Resource):
             query = Protocol.query\
                 .join(ProtocolPermission, Protocol.id == ProtocolPermission.protocol_id)\
                 .filter(ProtocolPermission.user_id == user_id)\
+                .filter(Protocol.id == protocol_id)\
                 .first()
             return jsonRow2dict(query)
         raise AuthError({

--- a/server/api/run.py
+++ b/server/api/run.py
@@ -8,6 +8,10 @@ from database import jsonRow2dict, Run, RunPermission
 from api.utils import success_output
 
 
+import json
+import sys
+
+
 api = Namespace('runs', description='Extra-Simple operations on runs.', path='/')
 
 
@@ -63,6 +67,7 @@ class RunResource(Resource):
             query = Run.query\
                 .join(RunPermission, Run.id == RunPermission.run_id)\
                 .filter(RunPermission.user_id == user_id)\
+                .filter(Run.id == run_id)\
                 .first()
             return jsonRow2dict(query)
         raise AuthError({

--- a/web/src/components/RunBlockEditor.tsx
+++ b/web/src/components/RunBlockEditor.tsx
@@ -57,7 +57,7 @@ function RunBlockOptionsQuestion({disabled, definition, answer, setAnswer}: {
                     value={answer}
                     onChange={(e: React.ChangeEvent<HTMLSelectElement>) => setAnswer((e.target as HTMLSelectElement).value)}
                 >
-                    {definition.options && definition.options.map((option, i) => <option key={i}>{option}</option>)}
+                    {definition.options && definition.options.map(option => <option key={option.id}>{option.option}</option>)}
                 </Form.Control>
             </Form.Group>
     }


### PR DESCRIPTION
Was missing a where clause on the run/protocol id in the GET api lookup. This was just returning the first run/protocol in the table that the user had permissions to read.