### PR TITLE
Editing buttons and labels to match protocol

### DIFF
--- a/web/src/components/ProtocolBlockEditor.tsx
+++ b/web/src/components/ProtocolBlockEditor.tsx
@@ -157,8 +157,8 @@ function ProtocolBlockPlateEditor<T extends number = number>({ disabled, label, 
             </DropdownButton>
             <FormControl
                 disabled={disabled}
-                placeholder="Enter a plate label"
-                aria-label="Enter a plate label"
+                placeholder="Enter a plate type"
+                aria-label="Enter a plate type"
                 value={plateName}
                 onChange={(e: React.ChangeEvent<HTMLInputElement>) => setName((e.target as HTMLInputElement).value)}
             />
@@ -169,14 +169,14 @@ function ProtocolBlockPlateEditor<T extends number = number>({ disabled, label, 
 function ProtocolBlockPlateCountEditor({ disabled, plateCount, setPlateCount }: {
     disabled?: boolean;
     plateCount?: number;
-    setPlateCount: (plateCount?: number) => void;
+    setPlateCount: (plateCount?: string) => void;
 }) {
     return <Form.Group>
-        <Form.Label>Number of plates</Form.Label>
+        <Form.Label>Number of plates to transfer</Form.Label>
         <Form.Control
             disabled={disabled}
             type="number"
-            placeholder="Enter a number"
+            placeholder="Enter a number: 4"
             value={plateCount}
             onChange={(e: React.ChangeEvent<HTMLInputElement>) => setPlateCount(parseInt((e.target as HTMLInputElement).value))}
         />
@@ -295,7 +295,7 @@ export function ProtocolBlockEditor(props: ProtocolBlockEditorProps) {
                     label="Plate to add reagent to"
                     plateName={block.plateName}
                     plateSize={block.plateSize}
-                    plateSizes={[96, 384]}
+                    plateSizes={[384, 96]}
                     setPlateName={plateName => props.setBlock({ ...block, type: 'plate-add-reagent', plateName })}
                     setPlateSize={plateSize => props.setBlock({ ...block, type: 'plate-add-reagent', plateSize })}
                 />

--- a/web/src/components/RunBlockEditor.tsx
+++ b/web/src/components/RunBlockEditor.tsx
@@ -140,9 +140,9 @@ function RunBlockPlateLabelUploader({disabled, wells, plateLabel, setCoordinates
     return <>
         <TableUploadModal
             columns={{
-                'plate': 0,
-                'cell': 1,
-                'sample': 2,
+                'plate': 1,
+                'cell': 2,
+                'sample': 3,
             }}
             show={showUploader}
             setShow={setShowUploader}
@@ -159,7 +159,7 @@ function RunBlockPlateLabelUploader({disabled, wells, plateLabel, setCoordinates
             />
             <InputGroup.Append>
                 <Button variant="secondary" disabled={disabled} onClick={() => setShowUploader(true)}>
-                    <UpcScan /> Scan
+                    Upload
                 </Button>
             </InputGroup.Append>
         </InputGroup>
@@ -178,8 +178,8 @@ function RunBlockPlateLabelEditor({disabled, wells, label, setLabel}: {
         </InputGroup.Prepend>
         <FormControl
             disabled={disabled}
-            placeholder="Enter a plate label"
-            aria-label="Enter a plate label"
+            placeholder="Scan the plate barcode"
+            aria-label="Scan the plate barcode"
             value={label}
             onChange={(e: React.ChangeEvent<HTMLInputElement>) => setLabel((e.target as HTMLInputElement).value)}
         />
@@ -189,6 +189,27 @@ function RunBlockPlateLabelEditor({disabled, wells, label, setLabel}: {
             </Button>
         </InputGroup.Append>
     </InputGroup>
+}
+
+function RunBlockPlateLotEditor({disabled, lot, setLot}: {
+  disabled?: boolean;
+  lot?: string;
+  setLot: (lot?: string) => void;
+}) {
+  return <InputGroup>
+      <FormControl
+          disabled={disabled}
+          placeholder="Enter or scan the lot number"
+          aria-label="Enter or scan the lot number"
+          value={lot}
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) => setLot((e.target as HTMLInputElement).value)}
+      />
+      <InputGroup.Append>
+          <Button variant="secondary" disabled={true}>
+              <UpcScan /> Scan
+          </Button>
+      </InputGroup.Append>
+  </InputGroup>
 }
 
 function RunBlockPlateSamplerEditor({disabled, definition, outputPlateLabel, setOutputPlateLabel, mappings, setMappings}: {
@@ -246,13 +267,16 @@ function RunBlockPlateSamplerEditor({disabled, definition, outputPlateLabel, set
     </Table>
 }
 
-function RunBlockPlateAddReagentEditor({disabled, definition, plateLabel, setPlateLabel}: {
+function RunBlockPlateAddReagentEditor({disabled, definition, plateLabel, setPlateLabel, plateLot, setPlateLot}: {
     disabled?: boolean;
     definition: PlateAddReagentBlockDefinition;
     plateLabel?: string;
+    plateLot?: string;
     setPlateLabel: (plateLabel?: string) => void;
+    setPlateLot: (plateLot?: string) => void;
 }) {
     return (
+      <InputGroup>
         <Form.Group>
             <Form.Label>Plate with reagent ({definition.reagentLabel}) added</Form.Label>
             <RunBlockPlateLabelEditor
@@ -261,7 +285,14 @@ function RunBlockPlateAddReagentEditor({disabled, definition, plateLabel, setPla
                 label={plateLabel}
                 setLabel={setPlateLabel}
             />
+            <Form.Label>Reagent lot number</Form.Label>
+            <RunBlockPlateLotEditor
+                disabled={disabled}
+                lot={plateLot}
+                setLot={setPlateLot}
+            />
         </Form.Group>
+      </InputGroup>
     );
 }
 
@@ -344,7 +375,9 @@ export function RunBlockEditor(props: RunBlockEditorProps) {
                     disabled={props.disabled}
                     definition={block.definition}
                     plateLabel={block.plateLabel}
+                    plateLot={block.plateLot}
                     setPlateLabel={plateLabel => props.setBlock({ ...block, type: 'plate-add-reagent', plateLabel })}
+                    setPlateLot={plateLot => props.setBlock({ ...block, type: 'plate-add-reagent', plateLot })}
                 />
             );
         }

--- a/web/src/components/RunBlockEditor.tsx
+++ b/web/src/components/RunBlockEditor.tsx
@@ -329,7 +329,7 @@ function RunBlockPlateSamplerEditor({disabled, definition, outputPlateLabel, set
         </tr>
     );
     return <>
-        <h3 className="row">{definition.name}</h3>
+        <h4 className="row">{definition.name}</h4>
         <Table>
             <thead>
                 <tr>
@@ -356,7 +356,8 @@ function RunBlockPlateAddReagentEditor({disabled, definition, plateLabel, setPla
     return (
       <InputGroup>
         <Form.Group>
-            <Form.Label>Plate with reagent ({definition.reagentLabel}) added</Form.Label>
+            <h4 className="row">{definition.name}</h4>
+            <Form.Label>Adding reagent ({definition.reagentLabel}) to plate</Form.Label>
             <RunBlockPlateLabelEditor
                 disabled={disabled}
                 wells={definition.plateSize}
@@ -403,7 +404,7 @@ function RunBlockPlateSequencerEditor({disabled, definition, plateLabels, setPla
         </tr>);
     }
     return <>
-        <h3 className="row">{definition.name}</h3>
+        <h4 className="row">{definition.name}</h4>
         <Table>
             <thead>
                 <tr>

--- a/web/src/models/block-definition.ts
+++ b/web/src/models/block-definition.ts
@@ -37,7 +37,7 @@ export interface PlateAddReagentBlockDefinition {
     id?: string;
     name?: string;
     plateName?: string;
-    plateSize?: 96 | 384;
+    plateSize?: 384 | 96;
     reagentLabel?: string;
 }
 
@@ -67,5 +67,5 @@ export interface PlateSequencerBlockDefinition {
     id?: string;
     name?: string;
     plateName?: string;
-    plateSize?: 96 | 384;
+    plateSize?: 384 | 96;
 }

--- a/web/src/models/block.ts
+++ b/web/src/models/block.ts
@@ -30,6 +30,7 @@ export interface PlateAddReagentBlock {
     definition: PlateAddReagentBlockDefinition;
 
     plateLabel?: string;
+    plateLot?: string;
 
     // TODO: lotId, etc.
 }

--- a/web/src/pages/ProtocolEditorPage.tsx
+++ b/web/src/pages/ProtocolEditorPage.tsx
@@ -184,10 +184,24 @@ export function ProtocolSectionEditor({disabled, index, section, setSection}: {
         }
     }
 
+    const updateSectionTitle = (sectionTitle?: string) => {
+      setSection({
+        ...section,
+        name: sectionTitle
+      });
+    }
+
     return <>
-        <h1 className="row">
-            Section {index + 1}: {(section && section.name) || 'Untitled Section'}
-        </h1>
+        <Form.Group>
+          <h3 className="row"><Form.Label>Protocol section:</Form.Label></h3>
+          <Form.Control
+            disabled={disabled}
+            type="text"
+            placeholder="Enter the title. A section has a signature block during a run."
+            value={(section && section.name)}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => updateSectionTitle((e.target as HTMLInputElement).value)}
+          />
+        </Form.Group>
 
         {currentBlocks.map((block, index) => {
             if (!block || !block.id) {
@@ -328,7 +342,7 @@ export function ProtocolEditorPage() {
         />
         <Form className="mt-4">
             <Form.Group>
-                <Form.Label>Protocol Title</Form.Label>
+                <Form.Label><h2 className="row">Protocol Title</h2></Form.Label>
                 <InputGroup>
                     <Form.Control
                         type="text"
@@ -385,7 +399,7 @@ export function ProtocolEditorPage() {
 
             <div className="row">
                 <Form.Group className="col-3 ml-auto">
-                    <Form.Label>Signature</Form.Label>
+                    <Form.Label>Protocol Signature</Form.Label>
                     <InputGroup>
                         <Form.Control
                             className="flow-signature"
@@ -420,7 +434,7 @@ export function ProtocolEditorPage() {
 
             <div className="row">
                 <Form.Group className="col-3 ml-auto">
-                    <Form.Label>Witness</Form.Label>
+                    <Form.Label>Protocol Witness</Form.Label>
                     <InputGroup>
                         <Form.Control
                             className="flow-signature"

--- a/web/src/pages/RunEditorPage.tsx
+++ b/web/src/pages/RunEditorPage.tsx
@@ -59,9 +59,6 @@ export function RunSectionEditor({disabled, index, section, setSection, syncSect
                 return undefined;
             }
             return <div>
-              <h4 className="row">
-                Step: {(block && block.definition.name) || 'Untitled Step'}
-              </h4>
               <RunBlockEditor
                 key={block.definition.id}
                 block={block}

--- a/web/src/pages/RunEditorPage.tsx
+++ b/web/src/pages/RunEditorPage.tsx
@@ -11,7 +11,7 @@ import { runQuery, upsertRun } from '../state/selectors';
 import { Block } from '../models/block';
 import { deserializeSlate, serializeSlate } from '../slate';
 import moment from 'moment';
-import { CheckCircle, Share } from 'react-bootstrap-icons';
+import { BlockquoteLeft, CheckCircle, Share } from 'react-bootstrap-icons';
 import { SharingModal } from '../components/SharingModal';
 import { Element, Leaf, onHotkeyDown, Toolbar } from '../components/Slate';
 
@@ -50,20 +50,25 @@ export function RunSectionEditor({disabled, index, section, setSection, syncSect
     };
 
     return <>
-        <h1 className="row">
-            Section {index}: {(section && section.definition.name) || 'Untitled Section'}
-        </h1>
+        <h2 className="row">
+            <i>Section: {(section && section.definition.name) || 'Untitled Section'}</i>
+        </h2>
 
         {currentBlocks.map(block => {
             if (!block || !block.definition || !block.definition.id) {
                 return undefined;
             }
-            return <RunBlockEditor
+            return <div>
+              <h4 className="row">
+                Step: {(block && block.definition.name) || 'Untitled Step'}
+              </h4>
+              <RunBlockEditor
                 key={block.definition.id}
                 block={block}
                 setBlock={updateBlock}
                 disabled={isSigned || isWitnessed}
-            />
+              />
+            </div>
         })}
 
         <div className="row">
@@ -233,6 +238,7 @@ export function RunEditorPage() {
                     <Share /> Share
                 </Button>
             </div>
+            <br></br>
             <Form.Group>
                 <Form.Label>Notes</Form.Label>
                 <Slate
@@ -244,7 +250,7 @@ export function RunEditorPage() {
                     <Editable
                         renderElement={renderElement}
                         renderLeaf={renderLeaf}
-                        placeholder="Enter a description here..."
+                        placeholder="Enter run notes here..."
                         onKeyDown={onHotkeyDown(editor)}
                         spellCheck
                         disabled={isCompleted}


### PR DESCRIPTION
Changed "scan" to "upload" for the plate sampler upload buttons.
I made some of the defaults 384-well instead of 96.
I added a "lot" field to the reagent run block, since this has to be entered or scanned when adding a reagent.
