### PR TITLE
rename Thermocycler blocks to be generic Timestamp blocks

### DIFF
--- a/web/src/components/ProtocolBlockEditor.tsx
+++ b/web/src/components/ProtocolBlockEditor.tsx
@@ -1,12 +1,12 @@
 import React, { useState } from 'react';
 import { Button, Dropdown, DropdownButton, Form, FormControl, InputGroup } from 'react-bootstrap';
 import { GripHorizontal, Trash } from 'react-bootstrap-icons';
-import { BlockDefinition, BlockOption, BlockPlate, BlockPlateMarkerEntry, BlockPrimer, BlockVariable, EndThermocyclerBlockDefinition, OptionsQuestionBlockDefinition, PlateAddReagentBlockDefinition, PlateSamplerBlockDefinition, PlateSequencerBlockDefinition, StartThermocyclerBlockDefinition, TextQuestionBlockDefinition } from '../models/block-definition';
+import { BlockDefinition, BlockOption, BlockPlate, BlockPlateMarkerEntry, BlockPrimer, BlockVariable, EndTimestampBlockDefinition, OptionsQuestionBlockDefinition, PlateAddReagentBlockDefinition, PlateSamplerBlockDefinition, PlateSequencerBlockDefinition, StartTimestampBlockDefinition, TextQuestionBlockDefinition } from '../models/block-definition';
 import { trimEmpty } from '../utils';
 import * as uuid from 'uuid';
 import { TableUploadModal } from './TableUploadModal';
 
-export function humanizeBlockType(blockType: "text-question" | "options-question" | "plate-sampler" | "plate-add-reagent" | "start-thermocycler" | "end-thermocycler" | "plate-sequencer" | undefined): string {
+export function humanizeBlockType(blockType: "text-question" | "options-question" | "plate-sampler" | "plate-add-reagent" | "start-timestamp" | "end-timestamp" | "plate-sequencer" | undefined): string {
     switch (blockType) {
         case 'text-question':
             return 'Answer Question';
@@ -16,10 +16,10 @@ export function humanizeBlockType(blockType: "text-question" | "options-question
             return 'Run Plate Sampler';
         case 'plate-add-reagent':
             return 'Add Reagent to Plate';
-        case 'start-thermocycler':
-            return 'Start Thermocycler';
-        case 'end-thermocycler':
-            return 'End Thermocycler';
+        case 'start-timestamp':
+            return 'Start Timestamp';
+        case 'end-timestamp':
+            return 'End Timestamp';
         case 'plate-sequencer':
             return 'Run Plate Sequencer';
         default:
@@ -29,7 +29,7 @@ export function humanizeBlockType(blockType: "text-question" | "options-question
 
 function BlockLabel({ index, blockType }: {
     index: number;
-    blockType?: "text-question" | "options-question" | "plate-sampler" | "plate-add-reagent" | "start-thermocycler" | "end-thermocycler" | "plate-sequencer";
+    blockType?: "text-question" | "options-question" | "plate-sampler" | "plate-add-reagent" | "start-timestamp" | "end-timestamp" | "plate-sequencer";
 }) {
     return <div className="mb-2">
         <GripHorizontal /> Step {index+1} - {humanizeBlockType(blockType)}
@@ -621,26 +621,26 @@ export function ProtocolBlockEditor(props: ProtocolBlockEditorProps) {
                 />
             </>;
         }
-        case 'start-thermocycler': {
-            const block: StartThermocyclerBlockDefinition = props.block;
+        case 'start-timestamp': {
+            const block: StartTimestampBlockDefinition = props.block;
             return <>
                 <BlockLabel index={props.index} blockType={block.type} />
                 <ProtocolBlockNameEditor
                     disabled={props.disabled}
                     name={block.name}
-                    setName={name => props.setBlock({ ...block, type: 'start-thermocycler', name })}
+                    setName={name => props.setBlock({ ...block, type: 'start-timestamp', name })}
                     deleteStep={props.deleteBlock}
                 />
             </>;
         }
-        case 'end-thermocycler': {
-            const block: EndThermocyclerBlockDefinition = props.block;
+        case 'end-timestamp': {
+            const block: EndTimestampBlockDefinition = props.block;
             return <>
                 <BlockLabel index={props.index} blockType={block.type} />
                 <ProtocolBlockNameEditor
                     disabled={props.disabled}
                     name={block.name}
-                    setName={name => props.setBlock({ ...block, type: 'end-thermocycler', name })}
+                    setName={name => props.setBlock({ ...block, type: 'end-timestamp', name })}
                     deleteStep={props.deleteBlock}
                 />
             </>;

--- a/web/src/components/RunBlockEditor.tsx
+++ b/web/src/components/RunBlockEditor.tsx
@@ -2,8 +2,8 @@ import moment from 'moment';
 import React, { useState } from 'react';
 import { Button, Dropdown, DropdownButton, Form, FormControl, InputGroup, Table } from 'react-bootstrap';
 import { UpcScan } from 'react-bootstrap-icons';
-import { TextQuestionBlock, OptionsQuestionBlock, PlateSamplerBlock, PlateAddReagentBlock, PlateSequencerBlock, Block, PlateCoordinate, PlateResult, StartThermocyclerBlock, EndThermocyclerBlock } from '../models/block';
-import { BlockPrimer, EndThermocyclerBlockDefinition, OptionsQuestionBlockDefinition, PlateAddReagentBlockDefinition, PlateSamplerBlockDefinition, PlateSequencerBlockDefinition, StartThermocyclerBlockDefinition, TextQuestionBlockDefinition } from '../models/block-definition';
+import { TextQuestionBlock, OptionsQuestionBlock, PlateSamplerBlock, PlateAddReagentBlock, PlateSequencerBlock, Block, PlateCoordinate, PlateResult, StartTimestampBlock, EndTimestampBlock } from '../models/block';
+import { BlockPrimer, EndTimestampBlockDefinition, OptionsQuestionBlockDefinition, PlateAddReagentBlockDefinition, PlateSamplerBlockDefinition, PlateSequencerBlockDefinition, StartTimestampBlockDefinition, TextQuestionBlockDefinition } from '../models/block-definition';
 import { TableUploadModal } from './TableUploadModal';
 import DateRangePicker from 'react-bootstrap-daterangepicker';
 import { Calculator } from './Calculator';
@@ -468,11 +468,11 @@ function RunBlockPlateSequencerEditor({ disabled, definition, plateLabels, setPl
     </>
 }
 
-function RunBlockStartThermocyclerEditor({ disabled, definition, thermocyclerLabel, setThermocyclerLabel, startedOn, setStartedOn }: {
+function RunBlockStartTimestampEditor({ disabled, definition, timestampLabel, setTimestampLabel, startedOn, setStartedOn }: {
     disabled?: boolean;
-    definition: StartThermocyclerBlockDefinition;
-    thermocyclerLabel?: string;
-    setThermocyclerLabel: (thermocyclerLabel?: string) => void;
+    definition: StartTimestampBlockDefinition;
+    timestampLabel?: string;
+    setTimestampLabel: (timestampLabel?: string) => void;
     startedOn?: string;
     setStartedOn: (startedOn?: string) => void;
 }) {
@@ -480,14 +480,14 @@ function RunBlockStartThermocyclerEditor({ disabled, definition, thermocyclerLab
         <RunBlockLabel name={definition.name} />
         <div className="row">
             <Form.Group className="col">
-                <Form.Label>Thermocycler ID/Label</Form.Label>
+                <Form.Label>Timestamp ID/Label</Form.Label>
                 <Form.Control
                     disabled={disabled}
                     type="text"
                     placeholder="Enter a label or ID here..."
                     aria-placeholder="Enter a label or ID here..."
-                    value={thermocyclerLabel}
-                    onChange={(e: React.ChangeEvent<HTMLInputElement>) => setThermocyclerLabel((e.target as HTMLInputElement).value)}
+                    value={timestampLabel}
+                    onChange={(e: React.ChangeEvent<HTMLInputElement>) => setTimestampLabel((e.target as HTMLInputElement).value)}
                 />
             </Form.Group>
             <Form.Group className="col">
@@ -515,11 +515,11 @@ function RunBlockStartThermocyclerEditor({ disabled, definition, thermocyclerLab
     </>;
 }
 
-function RunBlockEndThermocyclerEditor({ disabled, definition, thermocyclerLabel, setThermocyclerLabel, endedOn, setEndedOn }: {
+function RunBlockEndTimestampEditor({ disabled, definition, timestampLabel, setTimestampLabel, endedOn, setEndedOn }: {
     disabled?: boolean;
-    definition: EndThermocyclerBlockDefinition;
-    thermocyclerLabel?: string;
-    setThermocyclerLabel: (thermocyclerLabel?: string) => void;
+    definition: EndTimestampBlockDefinition;
+    timestampLabel?: string;
+    setTimestampLabel: (timestampLabel?: string) => void;
     endedOn?: string;
     setEndedOn: (startedOn?: string) => void;
 }) {
@@ -527,14 +527,14 @@ function RunBlockEndThermocyclerEditor({ disabled, definition, thermocyclerLabel
         <RunBlockLabel name={definition.name} />
         <div className="row">
             <Form.Group className="col">
-                <Form.Label>Thermocycler ID/Label</Form.Label>
+                <Form.Label>Timestamp ID/Label</Form.Label>
                 <Form.Control
                     disabled={disabled}
                     type="text"
                     placeholder="Enter a label or ID here..."
                     aria-placeholder="Enter a label or ID here..."
-                    value={thermocyclerLabel}
-                    onChange={(e: React.ChangeEvent<HTMLInputElement>) => setThermocyclerLabel((e.target as HTMLInputElement).value)}
+                    value={timestampLabel}
+                    onChange={(e: React.ChangeEvent<HTMLInputElement>) => setTimestampLabel((e.target as HTMLInputElement).value)}
                 />
             </Form.Group>
             <Form.Group className="col">
@@ -553,8 +553,8 @@ function RunBlockEndThermocyclerEditor({ disabled, definition, thermocyclerLabel
                 >
                     <Form.Control
                         type="text"
-                        placeholder="Thermocycler ended on..."
-                        aria-placeholder="Thermocycler ended on..."
+                        placeholder="Timestamp ended on..."
+                        aria-placeholder="Timestamp ended on..."
                     />
                 </DateRangePicker>
             </Form.Group>
@@ -643,29 +643,29 @@ export function RunBlockEditor(props: RunBlockEditorProps) {
                 />
             );
         }
-        case 'start-thermocycler': {
-            const block: StartThermocyclerBlock = props.block;
+        case 'start-timestamp': {
+            const block: StartTimestampBlock = props.block;
             return (
-                <RunBlockStartThermocyclerEditor
+                <RunBlockStartTimestampEditor
                     disabled={props.disabled}
                     definition={block.definition}
-                    thermocyclerLabel={block.thermocyclerLabel}
-                    setThermocyclerLabel={thermocyclerLabel => props.setBlock({ ...block, type: 'start-thermocycler', thermocyclerLabel })}
+                    timestampLabel={block.timestampLabel}
+                    setTimestampLabel={timestampLabel => props.setBlock({ ...block, type: 'start-timestamp', timestampLabel })}
                     startedOn={block.startedOn}
-                    setStartedOn={startedOn => props.setBlock({ ...block, type: 'start-thermocycler', startedOn })}
+                    setStartedOn={startedOn => props.setBlock({ ...block, type: 'start-timestamp', startedOn })}
                 />
             );
         }
-        case 'end-thermocycler': {
-            const block: EndThermocyclerBlock = props.block;
+        case 'end-timestamp': {
+            const block: EndTimestampBlock = props.block;
             return (
-                <RunBlockEndThermocyclerEditor
+                <RunBlockEndTimestampEditor
                     disabled={props.disabled}
                     definition={block.definition}
-                    thermocyclerLabel={block.thermocyclerLabel}
-                    setThermocyclerLabel={thermocyclerLabel => props.setBlock({ ...block, type: 'end-thermocycler', thermocyclerLabel })}
+                    timestampLabel={block.timestampLabel}
+                    setTimestampLabel={timestampLabel => props.setBlock({ ...block, type: 'end-timestamp', timestampLabel })}
                     endedOn={block.endedOn}
-                    setEndedOn={endedOn => props.setBlock({ ...block, type: 'end-thermocycler', endedOn })}
+                    setEndedOn={endedOn => props.setBlock({ ...block, type: 'end-timestamp', endedOn })}
                 />
             );
         }

--- a/web/src/models/block-definition.ts
+++ b/web/src/models/block-definition.ts
@@ -1,4 +1,4 @@
-export type BlockDefinition = TextQuestionBlockDefinition | OptionsQuestionBlockDefinition | PlateSamplerBlockDefinition | PlateAddReagentBlockDefinition | PlateSequencerBlockDefinition | StartThermocyclerBlockDefinition | EndThermocyclerBlockDefinition;
+export type BlockDefinition = TextQuestionBlockDefinition | OptionsQuestionBlockDefinition | PlateSamplerBlockDefinition | PlateAddReagentBlockDefinition | PlateSequencerBlockDefinition | StartTimestampBlockDefinition | EndTimestampBlockDefinition;
 
 export interface BlockOption {
     id: string;
@@ -69,15 +69,15 @@ export interface PlateAddReagentBlockDefinition {
     variables?: BlockVariable[];
 }
 
-export interface StartThermocyclerBlockDefinition {
-    type: 'start-thermocycler';
+export interface StartTimestampBlockDefinition {
+    type: 'start-timestamp';
 
     id?: string;
     name?: string;
 }
 
-export interface EndThermocyclerBlockDefinition {
-    type: 'end-thermocycler';
+export interface EndTimestampBlockDefinition {
+    type: 'end-timestamp';
 
     id?: string;
     name?: string;

--- a/web/src/models/block.ts
+++ b/web/src/models/block.ts
@@ -1,6 +1,6 @@
-import { EndThermocyclerBlockDefinition, OptionsQuestionBlockDefinition, PlateAddReagentBlockDefinition, PlateSamplerBlockDefinition, PlateSequencerBlockDefinition, StartThermocyclerBlockDefinition, TextQuestionBlockDefinition } from "./block-definition";
+import { EndTimestampBlockDefinition, OptionsQuestionBlockDefinition, PlateAddReagentBlockDefinition, PlateSamplerBlockDefinition, PlateSequencerBlockDefinition, StartTimestampBlockDefinition, TextQuestionBlockDefinition } from "./block-definition";
 
-export type Block = TextQuestionBlock | OptionsQuestionBlock | PlateSamplerBlock | PlateAddReagentBlock | PlateSequencerBlock | StartThermocyclerBlock | EndThermocyclerBlock;
+export type Block = TextQuestionBlock | OptionsQuestionBlock | PlateSamplerBlock | PlateAddReagentBlock | PlateSequencerBlock | StartTimestampBlock | EndTimestampBlock;
 
 export interface TextQuestionBlock {
     type: 'text-question';
@@ -36,19 +36,19 @@ export interface PlateAddReagentBlock {
     // TODO: Save input calculator variables.
 }
 
-export interface StartThermocyclerBlock {
-    type: 'start-thermocycler';
-    definition: StartThermocyclerBlockDefinition;
+export interface StartTimestampBlock {
+    type: 'start-timestamp';
+    definition: StartTimestampBlockDefinition;
 
-    thermocyclerLabel?: string;
+    timestampLabel?: string;
     startedOn?: string;
 }
 
-export interface EndThermocyclerBlock {
-    type: 'end-thermocycler';
-    definition: EndThermocyclerBlockDefinition;
+export interface EndTimestampBlock {
+    type: 'end-timestamp';
+    definition: EndTimestampBlockDefinition;
 
-    thermocyclerLabel?: string;
+    timestampLabel?: string;
     endedOn?: string;
 }
 

--- a/web/src/pages/ProtocolEditorPage.tsx
+++ b/web/src/pages/ProtocolEditorPage.tsx
@@ -231,8 +231,8 @@ export function ProtocolSectionEditor({disabled, index, section, setSection}: {
                         <Dropdown.Item onClick={() => addBlock({ id: uuid.v4(), type: 'options-question' })}>Options Question</Dropdown.Item>
                         <Dropdown.Item onClick={() => addBlock({ id: uuid.v4(), type: 'plate-sampler' })}>Run Plate Sampler</Dropdown.Item>
                         <Dropdown.Item onClick={() => addBlock({ id: uuid.v4(), type: 'plate-add-reagent' })}>Add Reagent to Plate</Dropdown.Item>
-                        <Dropdown.Item onClick={() => addBlock({ id: uuid.v4(), type: 'start-thermocycler' })}>Start Thermocycler</Dropdown.Item>
-                        <Dropdown.Item onClick={() => addBlock({ id: uuid.v4(), type: 'end-thermocycler' })}>End Thermocycler</Dropdown.Item>
+                        <Dropdown.Item onClick={() => addBlock({ id: uuid.v4(), type: 'start-timestamp' })}>Start Timestamp</Dropdown.Item>
+                        <Dropdown.Item onClick={() => addBlock({ id: uuid.v4(), type: 'end-timestamp' })}>End Timestamp</Dropdown.Item>
                         <Dropdown.Item onClick={() => addBlock({ id: uuid.v4(), type: 'plate-sequencer' })}>Run Plate Sequencer</Dropdown.Item>
                     </Dropdown.Menu>
                 </Dropdown>


### PR DESCRIPTION
This change will allow the Thermocycler block to be used for various things that need a timestamp. (e.g. various steps that require timed defrost, or timed heating)
