### PR TITLE
Added timestamp to plate sequencer block

### DIFF
--- a/web/src/components/ProtocolBlockEditor.tsx
+++ b/web/src/components/ProtocolBlockEditor.tsx
@@ -614,12 +614,6 @@ export function ProtocolBlockEditor(props: ProtocolBlockEditorProps) {
                         props.setBlock({ ...block, type: 'plate-sequencer', plateCount, plates });
                     }}
                 />
-                <ProtocolBlockNameEditor
-                    disabled={props.disabled}
-                    name={block.name}
-                    setName={name => props.setBlock({ ...block, type: 'start-timestamp', name })}
-                    deleteStep={props.deleteBlock}
-                />
                 <ProtocolBlockMarkersUploader
                     disabled={props.disabled}
                     plateMarkers={block.plateMarkers}

--- a/web/src/components/ProtocolBlockEditor.tsx
+++ b/web/src/components/ProtocolBlockEditor.tsx
@@ -614,6 +614,12 @@ export function ProtocolBlockEditor(props: ProtocolBlockEditorProps) {
                         props.setBlock({ ...block, type: 'plate-sequencer', plateCount, plates });
                     }}
                 />
+                <ProtocolBlockNameEditor
+                    disabled={props.disabled}
+                    name={block.name}
+                    setName={name => props.setBlock({ ...block, type: 'start-timestamp', name })}
+                    deleteStep={props.deleteBlock}
+                />
                 <ProtocolBlockMarkersUploader
                     disabled={props.disabled}
                     plateMarkers={block.plateMarkers}

--- a/web/src/components/RunBlockEditor.tsx
+++ b/web/src/components/RunBlockEditor.tsx
@@ -418,13 +418,17 @@ function RunBlockPlateAddReagentEditor({ disabled, definition, plateLabel, setPl
     </>;
 }
 
-function RunBlockPlateSequencerEditor({ disabled, definition, plateLabels, setPlateLabels, results, setResults }: {
+function RunBlockPlateSequencerEditor({ disabled, definition, plateLabels, setPlateLabels, results, setResults, timestampLabel, setTimestampLabel, startedOn, setStartedOn }: {
     disabled?: boolean;
     definition: PlateSequencerBlockDefinition;
     plateLabels?: string[];
     setPlateLabels: (plateLabels?: string[]) => void;
     results?: PlateResult[];
     setResults: (results?: PlateResult[]) => void;
+    timestampLabel?: string;
+    setTimestampLabel: (timestampLabel?: string) => void;
+    startedOn?: string;
+    setStartedOn: (startedOn?: string) => void;
 }) {
     const inputRows: JSX.Element[] = [];
     for (let i = 0; i < (definition.plateCount || 0); i++) {
@@ -460,6 +464,38 @@ function RunBlockPlateSequencerEditor({ disabled, definition, plateLabels, setPl
                 {inputRows}
             </tbody>
         </Table>
+        <Form.Group className="col">
+            <Form.Label>Timestamp ID/Label</Form.Label>
+            <Form.Control
+                disabled={disabled}
+                type="text"
+                placeholder="Enter a label or ID here..."
+                aria-placeholder="Enter a label or ID here..."
+                value={timestampLabel}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) => setTimestampLabel((e.target as HTMLInputElement).value)}
+            />
+        </Form.Group>
+        <Form.Group className="col">
+            <Form.Label>Started On</Form.Label>
+            <InputGroup>
+                <DatePicker
+                    selected={startedOn ? moment(startedOn).toDate() : undefined}
+                    onChange={start => {
+                        if (start && (start instanceof Date)) {
+                            setStartedOn(moment(start).format());
+                        }
+                    }}
+                    placeholderText="Click here to set a date/time..."
+                    todayButton="Now"
+                    showTimeSelect
+                    dateFormat="Pp"
+                    customInput={<Form.Control />}
+                />
+                <InputGroup.Append>
+                    <Button variant="secondary" onClick={() => setStartedOn(moment().format())}>Now</Button>
+                </InputGroup.Append>
+            </InputGroup>
+        </Form.Group>
         <RunBlockSequencerResultsUploader
             disabled={disabled}
             results={results}
@@ -640,6 +676,10 @@ export function RunBlockEditor(props: RunBlockEditorProps) {
                     setPlateLabels={plateLabels => props.setBlock({ ...block, type: 'plate-sequencer', plateLabels })}
                     results={props.block && props.block.plateSequencingResults}
                     setResults={plateSequencingResults => props.setBlock({ ...block, type: 'plate-sequencer', plateSequencingResults })}
+                    timestampLabel={block.timestampLabel}
+                    setTimestampLabel={timestampLabel => props.setBlock({ ...block, type: 'plate-sequencer', timestampLabel })}
+                    startedOn={block.startedOn}
+                    setStartedOn={startedOn => props.setBlock({ ...block, type: 'plate-sequencer', startedOn })}
                 />
             );
         }

--- a/web/src/components/RunBlockEditor.tsx
+++ b/web/src/components/RunBlockEditor.tsx
@@ -437,7 +437,7 @@ function RunBlockPlateSequencerEditor({ disabled, definition, plateLabels, setPl
             <td>
                 <RunBlockPlateLabelEditor
                     disabled={disabled}
-                    wells={definition.plates && definition.plates[i] && definition.plates[i].size}
+                    wells={384}
                     name={definition.plates && definition.plates[i] && definition.plates[i].name}
                     label={plateLabels ? plateLabels[i] : undefined}
                     setLabel={label => {

--- a/web/src/models/block.ts
+++ b/web/src/models/block.ts
@@ -58,6 +58,8 @@ export interface PlateSequencerBlock {
 
     plateLabels?: string[];
     plateSequencingResults?: PlateResult[];
+    timestampLabel?: string;
+    startedOn?: string;
 }
 
 export interface PlateResult {


### PR DESCRIPTION
In protocol I'm planning to call this block "start sequencer". So it has the necessary components: 
- scan the barcode(s) of the 384-well plates being pooled for sequencing
- timestamp when the run started

There is a 3rd component needed, where the user needs to enter the Basespace run ID. I'm planning to use the "Text question" box for that for now. I think it does make sense to keep this as a separate block, because some (many?) users will be processing sequencing results locally, so they won't have a Basespace run ID.

Note that the "upload results" step should be removed from this block when a new block is created that has this "upload" step (plus also API-based results retrieval).
